### PR TITLE
fix: stale queries in update semaphore

### DIFF
--- a/examples/rate-limit/main.go
+++ b/examples/rate-limit/main.go
@@ -88,12 +88,6 @@ func main() {
 		panic(err)
 	}
 
-	_, err = w.Start()
-
-	if err != nil {
-		panic(fmt.Errorf("error cleaning up: %w", err))
-	}
-
 	for i := 0; i < 12; i++ {
 		_, err = c.Admin().RunWorkflow("rate-limit-workflow", &rateLimitInput{
 			Index: i,


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change (pure documentation change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking changes to code which doesn't change any behaviour)
- [ ] CI (any automation pipeline changes)
- [ ] Chore (changes which are not directly related to any business logic)
- [ ] Test changes (add, refactor, improve or change a test)
- [ ] This change requires a documentation update

## What's Changed

- [ ] Add a list of tasks or features here...


<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit b4ed42ac76186a0ccbe72c12685e14bebafd766e.  | 
|--------|--------|

### Summary:
This PR involves minor changes in the `main.go` file and more substantial changes in the `step_runs.sql` and `step_runs.sql.go` files, including the addition of a new `step_run` subquery and changes in the `UpdateWorkerSemaphore` function.

**Key points**:
- Removed a block of code in `/examples/rate-limit/main.go`
- Added a new `step_run` subquery in the `AssignStepRunToWorker` function in `/internal/repository/prisma/dbsqlc/step_runs.sql`
- Made changes in the `UpdateWorkerSemaphore` function in `/internal/repository/prisma/dbsqlc/step_runs.sql`
- Reflected the changes made in the `step_runs.sql` file in the `step_runs.sql.go` file


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
